### PR TITLE
Default Playback Quality

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -78,75 +78,76 @@ class GoogleDriveAddon(CloudDriveAddon):
     
     def _get_item_play_url(self, file_name, driveid, item_driveid=None, item_id=None):
         url = None
-        if KodiUtils.get_addon_setting('ask_stream_format') == 'true':
-            url = self._select_stream_format(driveid, item_driveid, item_id)
+        if KodiUtils.get_addon_setting('ask_stream_format') == 'false':
+            if KodiUtils.get_addon_setting('default_stream_quality') == 'Original':
+                url = super(GoogleDriveAddon, self)._get_item_play_url(file_name, driveid, item_driveid, item_id)
+            else:
+                url = self._select_stream_format(driveid, item_driveid, item_id, True)
         if not url:
-            url = super(GoogleDriveAddon, self)._get_item_play_url(file_name, driveid, item_driveid, item_id)
+            url = self._select_stream_format(driveid, item_driveid, item_id, False)
         return url
     
-    def _select_stream_format(self, driveid, item_driveid=None, item_id=None):
+    def _select_stream_format(self, driveid, item_driveid=None, item_id=None, auto=False):
         url = None
-        stream_formats = self._get_stream_formats(self, driveid, item_driveid, item_id)
-        select = -1
-        if KodiUtils.get_addon_setting('ask_stream_format') == 'true':
-            select = self._dialog.select(self._addon.getLocalizedString(32016), stream_formats, 8000, 0)
-        else
-            select = self._auto_select_stream(stream_formats)
-        Logger.debug('Selected: %s' % Utils.str(select))
-        if select == -1:
-            self._cancel_operation = True
-        elif select != len(stream_formats) - 1:
-            data = fmt_list[select].split('/')
-            fmt_stream_map = Utils.get_safe_value(response_params, 'fmt_stream_map', '').split(',')
-            
-            for fmt in fmt_stream_map:
-                stream_data = fmt.split('|')
-                if stream_data[0] == data[0]:
-                    url = stream_data[1]
-                    break
-            if url:
-                cookie_header = ''
-                for cookie in request.response_cookies:
-                    if cookie_header: cookie_header += ';'
-                    cookie_header += cookie.name + '=' + cookie.value;
-                url += '|cookie=' + urllib.quote(cookie_header)
-        return url;
-        
-    def _auto_select_stream(self, streams):
-        select = -1
-        allowedQualitied = ['original','1080p','720p','480p','360p']
-        max_qual = KodiUtils.get_addon_setting('default_stream_quality')
-            if max_qual == '1080p'
-                allowedQualitied = ['1080p','720p','480p','360p','original']
-            elif max_qual == '720p'
-                allowedQualitied = ['720p','480p','360p','original']
-            elif max_qual == '480p'
-                allowedQualitied = ['480p','360p','original']
-            elif max_qual == '360p'
-                allowedQualitied = ['360p','original']
-            for q in allowedQualitied
-                if q in streams
-                    select = streams.index(q)
-                    break
-        return select
-    
-    def _get_stream_formats(self, driveid, item_driveid=None, item_id=None):
-        self._progress_dialog.update(0, self._addon.getLocalizedString(32009))
+        if auto == False:
+            self._progress_dialog.update(0, self._addon.getLocalizedString(32009))
         self._provider.configure(self._account_manager, driveid)
         self._provider.get_item(item_driveid, item_id)
         request = Request('https://drive.google.com/get_video_info', urllib.urlencode({'docid' : item_id}), {'authorization': 'Bearer %s' % self._provider.get_access_tokens()['access_token']})
         response_text = request.request()
         response_params = dict(urlparse.parse_qsl(response_text))
-        stream_formats = []
+        if auto == False:
+            self._progress_dialog.close()
         if Utils.get_safe_value(response_params, 'status', '') == 'ok':
             fmt_list = Utils.get_safe_value(response_params, 'fmt_list', '').split(',')
+            stream_formats = []
             for fmt in fmt_list:
                 data = fmt.split('/')
                 stream_formats.append(data[1])
-        stream_formats.append(self._addon.getLocalizedString(32015))
-        Logger.debug('Stream formats: %s' % Utils.str(stream_formats))
-        self._progress_dialog.close()
-        return stream_formats
+            stream_formats.append(self._addon.getLocalizedString(32015))
+            Logger.debug('Stream formats: %s' % Utils.str(stream_formats))
+            select = -1
+            if auto == True:
+                select = self._auto_select_stream(stream_formats)
+            else:
+                select = self._dialog.select(self._addon.getLocalizedString(32016), stream_formats, 8000, 0)
+            Logger.debug('Selected: %s' % Utils.str(select))
+            if select == -1:
+                self._cancel_operation = True
+            elif select != len(stream_formats) - 1:
+                data = fmt_list[select].split('/')
+                fmt_stream_map = Utils.get_safe_value(response_params, 'fmt_stream_map', '').split(',')
+                
+                for fmt in fmt_stream_map:
+                    stream_data = fmt.split('|')
+                    if stream_data[0] == data[0]:
+                        url = stream_data[1]
+                        break
+                if url:
+                    cookie_header = ''
+                    for cookie in request.response_cookies:
+                        if cookie_header: cookie_header += ';'
+                        cookie_header += cookie.name + '=' + cookie.value;
+                    url += '|cookie=' + urllib.quote(cookie_header)
+        return url
+
+    def _auto_select_stream(self, streams):
+        select = -1
+        allowedQualitied = ['Original format','1920x1080','1280x720','854x480','640x360']
+        max_qual = KodiUtils.get_addon_setting('default_stream_quality')
+        if max_qual == '1080p':
+            allowedQualitied = ['1920x1080','1280x720','854x480','640x360','Original format']
+        elif max_qual == '720p':
+            allowedQualitied = ['1280x720','854x480','640x360','Original format']
+        elif max_qual == '480p':
+            allowedQualitied = ['854x480','640x360','Original format']
+        elif max_qual == '360p':
+            allowedQualitied = ['640x360','Original format']
+        for q in allowedQualitied:
+            if q in streams:
+                select = streams.index(q)
+                break
+        return select
+
 if __name__ == '__main__':
     GoogleDriveAddon().route()
-

--- a/addon.py
+++ b/addon.py
@@ -86,42 +86,67 @@ class GoogleDriveAddon(CloudDriveAddon):
     
     def _select_stream_format(self, driveid, item_driveid=None, item_id=None):
         url = None
+        stream_formats = self._get_stream_formats(self, driveid, item_driveid, item_id)
+        select = -1
+        if KodiUtils.get_addon_setting('ask_stream_format') == 'true':
+            select = self._dialog.select(self._addon.getLocalizedString(32016), stream_formats, 8000, 0)
+        else
+            select = self._auto_select_stream(stream_formats)
+        Logger.debug('Selected: %s' % Utils.str(select))
+        if select == -1:
+            self._cancel_operation = True
+        elif select != len(stream_formats) - 1:
+            data = fmt_list[select].split('/')
+            fmt_stream_map = Utils.get_safe_value(response_params, 'fmt_stream_map', '').split(',')
+            
+            for fmt in fmt_stream_map:
+                stream_data = fmt.split('|')
+                if stream_data[0] == data[0]:
+                    url = stream_data[1]
+                    break
+            if url:
+                cookie_header = ''
+                for cookie in request.response_cookies:
+                    if cookie_header: cookie_header += ';'
+                    cookie_header += cookie.name + '=' + cookie.value;
+                url += '|cookie=' + urllib.quote(cookie_header)
+        return url;
+        
+    def _auto_select_stream(self, streams):
+        select = -1
+        allowedQualitied = ['original','1080p','720p','480p','360p']
+        max_qual = KodiUtils.get_addon_setting('default_stream_quality')
+            if max_qual == '1080p'
+                allowedQualitied = ['1080p','720p','480p','360p','original']
+            elif max_qual == '720p'
+                allowedQualitied = ['720p','480p','360p','original']
+            elif max_qual == '480p'
+                allowedQualitied = ['480p','360p','original']
+            elif max_qual == '360p'
+                allowedQualitied = ['360p','original']
+            for q in allowedQualitied
+                if q in streams
+                    select = streams.index(q)
+                    break
+        return select
+    
+    def _get_stream_formats(self, driveid, item_driveid=None, item_id=None):
         self._progress_dialog.update(0, self._addon.getLocalizedString(32009))
         self._provider.configure(self._account_manager, driveid)
         self._provider.get_item(item_driveid, item_id)
         request = Request('https://drive.google.com/get_video_info', urllib.urlencode({'docid' : item_id}), {'authorization': 'Bearer %s' % self._provider.get_access_tokens()['access_token']})
         response_text = request.request()
         response_params = dict(urlparse.parse_qsl(response_text))
-        self._progress_dialog.close()
+        stream_formats = []
         if Utils.get_safe_value(response_params, 'status', '') == 'ok':
             fmt_list = Utils.get_safe_value(response_params, 'fmt_list', '').split(',')
-            stream_formats = []
             for fmt in fmt_list:
                 data = fmt.split('/')
                 stream_formats.append(data[1])
-            stream_formats.append(self._addon.getLocalizedString(32015))
-            Logger.debug('Stream formats: %s' % Utils.str(stream_formats))
-            select = self._dialog.select(self._addon.getLocalizedString(32016), stream_formats, 8000, 0)
-            Logger.debug('Selected: %s' % Utils.str(select))
-            if select == -1:
-                self._cancel_operation = True
-            elif select != len(stream_formats) - 1:
-                data = fmt_list[select].split('/')
-                fmt_stream_map = Utils.get_safe_value(response_params, 'fmt_stream_map', '').split(',')
-                
-                for fmt in fmt_stream_map:
-                    stream_data = fmt.split('|')
-                    if stream_data[0] == data[0]:
-                        url = stream_data[1]
-                        break
-                if url:
-                    cookie_header = ''
-                    for cookie in request.response_cookies:
-                        if cookie_header: cookie_header += ';'
-                        cookie_header += cookie.name + '=' + cookie.value;
-                    url += '|cookie=' + urllib.quote(cookie_header)
-        return url;
-    
+        stream_formats.append(self._addon.getLocalizedString(32015))
+        Logger.debug('Stream formats: %s' % Utils.str(stream_formats))
+        self._progress_dialog.close()
+        return stream_formats
 if __name__ == '__main__':
     GoogleDriveAddon().route()
 

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.googledrive" name="Google Drive" version="1.2.12" provider-name="Carlos Guzman (cguZZman)">
+<addon id="plugin.googledrive" name="Google Drive" version="1.3.0" provider-name="Carlos Guzman (cguZZman)">
 	<requires>
 		<import addon="xbmc.python" version="2.25.0" />
 		<import addon="script.module.clouddrive.common" version="1.2.8"/>
@@ -37,6 +37,8 @@ Play all your media from Google Drive including Videos, Music and Pictures (incl
 		<forum>https://github.com/cguZZman/plugin.googledrive/issues</forum>
 		<website>https://addons.kodi.tv/show/plugin.googledrive</website>
 		<news>
+v1.3.0 released Jan 4, 2019:
+- Ability to specify default playback quality
 v1.2.12 released Oct 2, 2018:
 - Google Photos resolution fix
 v1.2.11 released Sep 20, 2018:

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -131,23 +131,3 @@ msgstr ""
 msgctxt "#32070"
 msgid "Default stream quality"
 msgstr ""
-
-msgctxt "#32071"
-msgid "Original"
-msgstr ""
-
-msgctxt "#32072"
-msgid "1080p"
-msgstr ""
-
-msgctxt "#32073"
-msgid "720p"
-msgstr ""
-
-msgctxt "#32074"
-msgid "480p"
-msgstr ""
-
-msgctxt "#32075"
-msgid "360p"
-msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -127,3 +127,27 @@ msgstr ""
 msgctxt "#32069"
 msgid "     Source server port  -  http://localhost:<port>/source"
 msgstr ""
+
+msgctxt "#32070"
+msgid "Default stream quality"
+msgstr ""
+
+msgctxt "#32071"
+msgid "Original"
+msgstr ""
+
+msgctxt "#32072"
+msgid "1080p"
+msgstr ""
+
+msgctxt "#32073"
+msgid "720p"
+msgstr ""
+
+msgctxt "#32074"
+msgid "480p"
+msgstr ""
+
+msgctxt "#32075"
+msgid "360p"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,28 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings >
     <category label="32067">
-    	<setting label="32000" type="lsep"/>
-    	<setting label="32004" type="bool" id="set_subtitle" default="true" value="true"/>
-    	<setting label="32011" type="bool" id="resume_playing" default="true" visible="!String.IsEmpty(window(home).property(iskrypton))" />
-    	<setting label="32018" type="bool" id="save_resume_watched" default="true" visible="!String.IsEmpty(window(home).property(iskrypton))" />
-    	<setting label="32017" type="bool" id="ask_resume" default="true" visible="String.IsEmpty(window(home).property(iskrypton))" />
-		<setting label="32008" type="bool" id="ask_stream_format" default="false" value="false"/>
-    	<setting label="32001" type="lsep"/>
-    	<setting label="32003" type="bool" id="clean_folder" default="true" value="true"/>
-    	<setting label="32002" type="lsep"/>
-		<setting label="32068" type="bool" id="allow_directory_listing" default="true"/>
-		<setting label="32069" type="number" id="port_directory_listing" default="8587"/>
-    	<setting label="32005" type="lsep"/>
-		<setting label="32006" type="number" id="slideshow_refresh_interval" default="5" value="5"/>
-		<setting label="32010" type="bool" id="slideshow_recursive" default="false" value="false"/>
+        <setting label="32000" type="lsep"/>
+        <setting label="32004" type="bool" id="set_subtitle" default="true" value="true"/>
+        <setting label="32011" type="bool" id="resume_playing" default="true" visible="!String.IsEmpty(window(home).property(iskrypton))" />
+        <setting label="32018" type="bool" id="save_resume_watched" default="true" visible="!String.IsEmpty(window(home).property(iskrypton))" />
+        <setting label="32017" type="bool" id="ask_resume" default="true" visible="String.IsEmpty(window(home).property(iskrypton))" />
+        <setting label="32008" type="bool" id="ask_stream_format" default="false" value="false"/>
+        <setting label="32070" type="select" id="default_stream_quality" lvalues="32071|32072|32073|32074|32075" default="32071" value="32071" visible="eq(-1,false)" />
+        <setting label="32001" type="lsep"/>
+        <setting label="32003" type="bool" id="clean_folder" default="true" value="true"/>
+        <setting label="32002" type="lsep"/>
+        <setting label="32068" type="bool" id="allow_directory_listing" default="true"/>
+        <setting label="32069" type="number" id="port_directory_listing" default="8587"/>
+        <setting label="32005" type="lsep"/>
+        <setting label="32006" type="number" id="slideshow_refresh_interval" default="5" value="5"/>
+        <setting label="32010" type="bool" id="slideshow_recursive" default="false" value="false"/>
     </category>
     <category label="32032">
-		<setting label="32033" type="text" id="sign-in-server" default="https://drive-login.herokuapp.com"/>
-		<setting label="32034" type="number" id="cache-expiration-time" default="5"/>
-		<setting label="32035" type="action" option="close" action="RunPlugin(plugin://plugin.googledrive/?action=_clear_cache)"/>
-		<setting label="32012" type="action" option="close" action="RunPlugin(plugin://plugin.googledrive/?action=_open_common_settings)"/>
+        <setting label="32033" type="text" id="sign-in-server" default="https://drive-login.herokuapp.com"/>
+        <setting label="32034" type="number" id="cache-expiration-time" default="5"/>
+        <setting label="32035" type="action" option="close" action="RunPlugin(plugin://plugin.googledrive/?action=_clear_cache)"/>
+        <setting label="32012" type="action" option="close" action="RunPlugin(plugin://plugin.googledrive/?action=_open_common_settings)"/>
     </category>
-	<category label="32030">
-		<setting label="32031" type="bool" id="report_error" default="false"/>
+    <category label="32030">
+        <setting label="32031" type="bool" id="report_error" default="false"/>
     </category>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,7 +7,7 @@
         <setting label="32018" type="bool" id="save_resume_watched" default="true" visible="!String.IsEmpty(window(home).property(iskrypton))" />
         <setting label="32017" type="bool" id="ask_resume" default="true" visible="String.IsEmpty(window(home).property(iskrypton))" />
         <setting label="32008" type="bool" id="ask_stream_format" default="false" value="false"/>
-        <setting label="32070" type="select" id="default_stream_quality" lvalues="32071|32072|32073|32074|32075" default="32071" value="32071" visible="eq(-1,false)" />
+        <setting label="32070" type="labelenum" id="default_stream_quality" subsetting="true" lvalues="Original|1080p|720p|480p|360p" default="Original" value="Original"  enable="eq(-1,false)"/>
         <setting label="32001" type="lsep"/>
         <setting label="32003" type="bool" id="clean_folder" default="true" value="true"/>
         <setting label="32002" type="lsep"/>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,7 +7,7 @@
         <setting label="32018" type="bool" id="save_resume_watched" default="true" visible="!String.IsEmpty(window(home).property(iskrypton))" />
         <setting label="32017" type="bool" id="ask_resume" default="true" visible="String.IsEmpty(window(home).property(iskrypton))" />
         <setting label="32008" type="bool" id="ask_stream_format" default="false" value="false"/>
-        <setting label="32070" type="labelenum" id="default_stream_quality" subsetting="true" lvalues="Original|1080p|720p|480p|360p" default="Original" value="Original"  enable="eq(-1,false)"/>
+        <setting label="32070" type="labelenum" id="default_stream_quality" subsetting="true" values="Original|1080p|720p|480p|360p" default="Original" value="Original"  enable="eq(-1,false)"/>
         <setting label="32001" type="lsep"/>
         <setting label="32003" type="bool" id="clean_folder" default="true" value="true"/>
         <setting label="32002" type="lsep"/>


### PR DESCRIPTION
Adding a "Default stream quality" setting. This setting allows the user to specify:

- Original
- 1080p
- 720p
- 480p
- 360

When video is played, it will go down the list to find the highest available quality that is less than or equal to the one selected. Original quality is used as a fallback.