### PR TITLE
Improve populating custom drive folders

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -45,6 +45,8 @@ class GoogleDriveAddon(CloudDriveAddon):
     def get_custom_drive_folders(self, driveid):
         self._account_manager.load()
         drive_folders = []
+        if not driveid.isdigit():
+            return drive_folders
         drive_folders.append({'name' : self._common_addon.getLocalizedString(32058), 'path' : 'sharedWithMe'})
         if self._content_type == 'image':
             drive_folders.append({'name' : self._addon.getLocalizedString(32007), 'path' : 'photos'})


### PR DESCRIPTION
For personal drive, `permissionId` is used, where `permissionId` is a string of digits. For all other drives or folders, mix of upper and lower letters, digits and symbols are used for drive id.

In practice, custom drive folders are only needed for personal drives but not for team drives or folders. The changes could save one click when navigating into team drives.